### PR TITLE
Feature/psr 16 compliant cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,24 @@
 {
     "name": "glue-systems/sp-api-open-api",
-    "description": "OpenAPI-generated PHP clients for Amazon Selling Partner API",
+    "description": "Lightweight, flexible PHP library for making LWA-authorized requests to Amazon Selling Partner API (SP-API) via OpenAPI-generated classes",
     "type": "library",
     "keywords": [
-        "glue",
         "amazon",
         "sp-api",
         "selling-partner",
         "php",
-        "client"
+        "client",
+        "openapi",
+        "lwa"
     ],
     "license": "MIT",
     "authors": [
         {
+            "name": "Glue Systems, LLC Dev Team",
+            "role": "Package Creators"
+        }, {
             "name": "OpenAPI-Generator contributors",
             "homepage": "https://openapi-generator.tech"
-        }, {
-            "name": "Glue Systems Dev Team",
-            "role": "Organize API clients into package-able library"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/cache": "4.2.*",
-        "nesbot/carbon": "1.38.3",
-        "aws/aws-sdk-php": "^3.110"
+        "aws/aws-sdk-php": "^3.110",
+        "psr/simple-cache": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "glue-systems/sp-api-open-api",
-    "description": "Lightweight, flexible PHP library for making LWA-authorized requests to Amazon Selling Partner API (SP-API) via OpenAPI-generated classes",
+    "description": "Lightweight PHP 5.6+ library for making LWA-authorized requests to Amazon Selling Partner API (SP-API) via OpenAPI-generated classes",
     "type": "library",
     "keywords": [
         "amazon",

--- a/src/Services/Authenticator/ClientAuthenticator.php
+++ b/src/Services/Authenticator/ClientAuthenticator.php
@@ -10,8 +10,8 @@ use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\RequestOptions;
-use Illuminate\Cache\StoreInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\SimpleCache\CacheInterface;
 
 class ClientAuthenticator implements ClientAuthenticatorContract
 {
@@ -20,7 +20,7 @@ class ClientAuthenticator implements ClientAuthenticatorContract
     const CACHE_LIFE_BUFFER_IN_SECONDS = 60;
 
     /**
-     * @var StoreInterface
+     * @var CacheInterface
      */
     protected $cache;
 
@@ -35,8 +35,7 @@ class ClientAuthenticator implements ClientAuthenticatorContract
     protected $config;
 
     public function __construct(
-        // TODO: Change to Illuminate\Contracts\Cache\Store in upgrading to PHP 7+.
-        StoreInterface $cache,
+        CacheInterface $cache,
         callable $credentialProvider,
         SPAPIConfig $config
     ) {
@@ -66,7 +65,7 @@ class ClientAuthenticator implements ClientAuthenticatorContract
 
         $newToken = $this->generateNewLwaAccessToken();
 
-        $this->cache->put(
+        $this->cache->set(
             self::LWA_ACCESS_TOKEN_CACHE_KEY,
             $newToken['access_token'],
             $newToken['expires_in'] - self::CACHE_LIFE_BUFFER_IN_SECONDS

--- a/src/Services/SPAPIConfig.php
+++ b/src/Services/SPAPIConfig.php
@@ -136,7 +136,7 @@ class SPAPIConfig
             }
         }
 
-        if ($this->sandbox && !str_contains(strtolower($this->spApiBaseUrl), 'sandbox')) {
+        if ($this->sandbox && strpos(strtolower($this->spApiBaseUrl), 'sandbox') === false) {
             throw new \RuntimeException("Production URL detected! Invalid spApiBaseUrl '$this->spApiBaseUrl' when sandbox = true."
                 . " Please adjust your ENV to use the sandbox URL and associated credentials instead."
                 . " For more info, see the Amazon docs: https://developer-docs.amazon.com/amazon-shipping/docs/the-selling-partner-api-sandbox.");

--- a/tests/Helpers/ArrayCache.php
+++ b/tests/Helpers/ArrayCache.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Helpers;
+
+use Psr\SimpleCache\CacheInterface;
+
+class ArrayCache implements CacheInterface
+{
+    protected $storage = [];
+
+    public function get($key, $default = null)
+    {
+        if ($this->has($key)) {
+            return $this->storage[$key];
+        }
+        return $default;
+    }
+
+    public function set($key, $value, $ttl = null)
+    {
+        $this->storage[$key] = $value;
+    }
+
+    public function delete($key)
+    {
+        unset($this->storage[$key]);
+    }
+
+    public function clear()
+    {
+        throw new \RuntimeException("Method not implemented.");
+    }
+
+    public function getMultiple($keys, $default = null)
+    {
+        throw new \RuntimeException("Method not implemented.");
+    }
+
+    public function setMultiple($values, $ttl = null)
+    {
+        throw new \RuntimeException("Method not implemented.");
+    }
+
+    public function deleteMultiple($keys)
+    {
+        throw new \RuntimeException("Method not implemented.");
+    }
+
+    public function has($key)
+    {
+        return array_key_exists($key, $this->storage);
+    }
+}

--- a/tests/Helpers/functions.php
+++ b/tests/Helpers/functions.php
@@ -7,8 +7,23 @@ use Dotenv\Environment\DotenvFactory;
 use PhpOption\Option;
 
 /**
- * Code ported over from global env helper in illuminate/support 5.8.* (doesn't exist in 4.2.*).
- * TODO: Replace this with env() helper after upgrading to later versions of illuminate/support.
+ * Ported over from illuminate/support 5.8.* package.
+ */
+if (!function_exists('value')) {
+    /**
+     * Return the default value of the given value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    function value($value)
+    {
+        return $value instanceof Closure ? $value() : $value;
+    }
+}
+
+/**
+ * Ported over from illuminate/support 5.8.* package.
  */
 if (!function_exists('env')) {
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,28 +13,28 @@ use Dotenv\Exception\InvalidFileException;
 use Glue\SPAPI\OpenAPI\Services\Authenticator\ClientAuthenticator;
 use Glue\SPAPI\OpenAPI\Services\Factory\ClientFactory;
 use Glue\SPAPI\OpenAPI\Services\SPAPIConfig;
-use Illuminate\Cache\ArrayStore;
 // TODO: Switch to this after upgrading.
 // use PHPUnit\Framework\TestCase as BaseTestCase;
 use \PHPUnit_Framework_TestCase as BaseTestCase;
+use Tests\Helpers\ArrayCache;
 
 class TestCase extends BaseTestCase
 {
     /**
-     * @var ArrayStore
+     * @var ArrayCache
      */
     public static $arrayCache;
 
     // TODO: This will need to be changed to `public function setUp(): void` after upgrading.
     public function setUp()
     {
-        if (!self::$arrayCache instanceof ArrayStore) {
-            self::$arrayCache = new ArrayStore();
+        if (!self::$arrayCache instanceof ArrayCache) {
+            self::$arrayCache = new ArrayCache();
         }
 
         $this->loadEnv();
 
-        require_once(__DIR__ . '/helpers.php');
+        require_once(__DIR__ . '/Helpers/functions.php');
     }
 
     public function loadEnv()
@@ -73,7 +73,7 @@ class TestCase extends BaseTestCase
         ]);
 
         if (env('TESTING_ALWAYS_RESET_ARRAY_CACHE', false)) {
-            self::$arrayCache = new ArrayStore();
+            self::$arrayCache = new ArrayCache();
         }
         $credentialProvider  = $this->buildDotEnvCredentialProvider();
         $clientAuthenticator = new ClientAuthenticator(self::$arrayCache, $credentialProvider, $spApiConfig);


### PR DESCRIPTION
Included in this PR:

- **Breaking change** -- Removes dependency on `illuminate/cache` and replaces it with `psr/simple-cache`
    - Ensures compliance with [PSR-16: Common Interface for Caching Libraries](https://www.php-fig.org/psr/psr-16/)
    - Makes this package more framework-agnostic
- Removes dependency on `nesbot/carbon`
- Adds `ArrayCache` helper class so that PHPUnit tests can persist the same LWA access token without needing to bring in bulkier packages for a testing-only use-case