### PR TITLE
Adding 'READY_TO_SHIP' as an enumerable value

### DIFF
--- a/src/Clients/FulfillmentInboundV0/Model/ShipmentStatus.php
+++ b/src/Clients/FulfillmentInboundV0/Model/ShipmentStatus.php
@@ -54,6 +54,7 @@ class ShipmentStatus
     const IN_TRANSIT = 'IN_TRANSIT';
     const DELIVERED = 'DELIVERED';
     const CHECKED_IN = 'CHECKED_IN';
+    const READY_TO_SHIP = 'READY_TO_SHIP';
     
     /**
      * Gets allowable values of the enum
@@ -72,6 +73,7 @@ class ShipmentStatus
             self::IN_TRANSIT,
             self::DELIVERED,
             self::CHECKED_IN,
+            self::READY_TO_SHIP,
         ];
     }
 }


### PR DESCRIPTION
Adding 'READY_TO_SHIP' as an enumerable value to fix serialization issues when this value is returned in production from the FulfillmentInboundApi.